### PR TITLE
i/353: Focus the editor before executing a command

### DIFF
--- a/src/horizontallineui.js
+++ b/src/horizontallineui.js
@@ -35,7 +35,10 @@ export default class HorizontalLineUI extends Plugin {
 			view.bind( 'isEnabled' ).to( command, 'isEnabled' );
 
 			// Execute the command.
-			this.listenTo( view, 'execute', () => editor.execute( 'horizontalLine' ) );
+			this.listenTo( view, 'execute', () => {
+				editor.execute( 'horizontalLine' );
+				editor.editing.view.focus();
+			} );
 
 			return view;
 		} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Focus the editor before executing toolbar buttons' command. 

### Additonal information:
Master PR: https://github.com/ckeditor/ckeditor5/pull/6066